### PR TITLE
Bugfix/no matching on unmatchable models

### DIFF
--- a/digitalarchive/__init__.py
+++ b/digitalarchive/__init__.py
@@ -7,18 +7,9 @@ __version__ = "0.1.2"
 # Import DA models for convenience.
 from .models import (
     Subject,
-    Language,
-    Transcript,
-    Translation,
-    MediaFile,
     Contributor,
-    Donor,
     Coverage,
     Collection,
     Repository,
-    Publisher,
-    Type,
-    Right,
-    Classification,
     Document,
 )

--- a/digitalarchive/models.py
+++ b/digitalarchive/models.py
@@ -19,15 +19,27 @@ import digitalarchive.exceptions as exceptions
 
 
 @dataclass
-class Resource:
-    """Abstract parent class for all DigitalArchive objects."""
+class _Resource:
+    """
+    Abstract parent class for all DigitalArchive objects.
+
+    todo: Add custom __eq__ method.
+    """
 
     id: str
+
+
+class _MatchableResource(_Resource):
+    """Abstract class for Resources that can be searched against."""
 
     @classmethod
     def match(cls, **kwargs) -> matching.ResourceMatcher:
         """Find a record based on passed kwargs. Returns all if none passed"""
         return matching.ResourceMatcher(cls, **kwargs)
+
+
+class _HydrateableResource(_Resource):
+    """Abstract class for Resources that can be accessed and hydrated individually."""
 
     def pull(self):
         """Update a given record using data from the remote DA."""
@@ -59,7 +71,7 @@ class Resource:
 
 
 @dataclass
-class Subject(Resource):
+class Subject(_MatchableResource, _HydrateableResource):
     name: str
 
     # Optional fields
@@ -71,12 +83,12 @@ class Subject(Resource):
 
 
 @dataclass
-class Language(Resource):
+class Language(_Resource):
     name: Optional[str] = None
 
 
 @dataclass
-class _Asset(Resource):
+class _Asset(_HydrateableResource):
     """
     Abstract class representing fpr Translations, Transcriptions, and MediaFiles.
 
@@ -169,19 +181,19 @@ class MediaFile(_Asset):
 
 
 @dataclass
-class Contributor(Resource):
+class Contributor(_MatchableResource, _HydrateableResource):
     name: str
     endpoint: str = "contributor"
 
 
 @dataclass
-class Donor(Resource):
+class Donor(_Resource):
     name: str
     endpoint: str = "donor"
 
 
 @dataclass
-class Coverage(Resource):
+class Coverage(_MatchableResource, _HydrateableResource):
     uri: str
     name: str
     parent: Any
@@ -189,7 +201,7 @@ class Coverage(Resource):
 
 
 @dataclass
-class Collection(Resource):
+class Collection(_MatchableResource, _HydrateableResource):
     # Required Fields
     name: str
     slug: str
@@ -215,8 +227,9 @@ class Collection(Resource):
     # Internal Fields
     endpoint: str = "collection"
 
+
 @dataclass
-class Repository(Resource):
+class Repository(_MatchableResource, _HydrateableResource):
     name: str
     uri: Optional[str] = None
     value: Optional[str] = None
@@ -224,30 +237,30 @@ class Repository(Resource):
 
 
 @dataclass
-class Publisher(Resource):
+class Publisher(_Resource):
     name: str
     value: str
     endpoint: str = "publisher"
 
 
 @dataclass
-class Type(Resource):
+class Type(_Resource):
     name: str
 
 
 @dataclass
-class Right(Resource):
+class Right(_Resource):
     name: str
     rights: str
 
 
 @dataclass
-class Classification(Resource):
+class Classification(_Resource):
     name: str
 
 
 @dataclass
-class Document(Resource):
+class Document(_MatchableResource, _HydrateableResource):
 
     # pylint: disable=too-many-instance-attributes
 

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -119,6 +119,7 @@ class TestCollection:
 
 
 class TestTranslation:
+
     def test_hydrate(self):
         """Test hydration method for digitalarchive.models._Asset"""
         # Fetch a translation

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -52,10 +52,10 @@ class TestDocument:
         assert len(record.transcripts) != 0
 
         for translation in record.translations:
-            assert isinstance(translation, digitalarchive.Translation)
+            assert isinstance(translation, digitalarchive.models.Translation)
 
         for transcript in record.transcripts:
-            assert isinstance(transcript, digitalarchive.Transcript)
+            assert isinstance(transcript, digitalarchive.models.Transcript)
 
     def test_hydrate_resultset(self):
         results = digitalarchive.Document.match(description="soviet eurasia")

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -1,5 +1,5 @@
 """Unit Tests of matching digitalarchive.matching."""
-# pylint: disable=missing-function-docstring, no-self-use,too-few-public-methods
+# pylint: disable=missing-function-docstring, no-self-use,too-few-public-methods,protected-access
 
 # Standard Library
 import unittest.mock
@@ -51,7 +51,7 @@ class TestResourceMatcher:
         """Test Search API called with proper params."""
         # Run match
         mock_get_by_id.return_value = {"list": [{"id": 1}]}
-        test_match = matching.ResourceMatcher(models.Resource, id=1)
+        test_match = matching.ResourceMatcher(models._Resource, id=1)
 
         # Check search called with proper params.
         mock_get_by_id.assert_called_once()
@@ -59,7 +59,7 @@ class TestResourceMatcher:
         # Inspect list for proper data
         match_results = list(test_match.list)
         assert len(match_results) == 1
-        assert isinstance(match_results[0], models.Resource)
+        assert isinstance(match_results[0], models._Resource)
 
     @unittest.mock.patch("digitalarchive.api.get")
     def test_match_record_by_id(self, mock_api_get):
@@ -82,15 +82,15 @@ class TestResourceMatcher:
 
     def test_invalid_keyword(self):
         with pytest.raises(exceptions.InvalidSearchFieldError):
-            models.Resource.match(test="test")
+            models._MatchableResource.match(test="test")
 
     @unittest.mock.patch("digitalarchive.matching.ResourceMatcher._record_by_id")
     def test_first(self, mock_get_by_id):
         # Run match
         mock_get_by_id.return_value = {"list": [{"id": 1}]}
-        test_match = matching.ResourceMatcher(models.Resource, id=1).first()
+        test_match = matching.ResourceMatcher(models._Resource, id=1).first()
 
-        assert isinstance(test_match, models.Resource)
+        assert isinstance(test_match, models._Resource)
 
     @unittest.mock.patch("digitalarchive.api.search")
     def test_all(self, mock_search):


### PR DESCRIPTION
Prevent users from running searches against models that do not have a search endpoint, such as `models.Translation`. Also prevents users from pulling or hydrating models that cannot be hydrated, such as `models.Donor` or `Models.Right`