### PR TITLE
Fix comparisons between hydrated and unhydrated models

### DIFF
--- a/digitalarchive/models.py
+++ b/digitalarchive/models.py
@@ -18,17 +18,27 @@ import digitalarchive.api as api
 import digitalarchive.exceptions as exceptions
 
 
-@dataclass
+@dataclass(eq=False)
 class _Resource:
     """
     Abstract parent class for all DigitalArchive objects.
 
-    todo: Add custom __eq__ method.
+    We add custom hash and eq fields so hydrated and unhydrated records are equal.
     """
 
     id: str
 
+    def __hash__(self):
+        return hash(self.id)
 
+    def __eq__(self, other):
+        if not self.__class__ == other.__class__:
+            return NotImplemented
+        else:
+            return self.id == other.id
+
+
+@dataclass(eq=False)
 class _MatchableResource(_Resource):
     """Abstract class for Resources that can be searched against."""
 
@@ -38,6 +48,7 @@ class _MatchableResource(_Resource):
         return matching.ResourceMatcher(cls, **kwargs)
 
 
+@dataclass(eq=False)
 class _HydrateableResource(_Resource):
     """Abstract class for Resources that can be accessed and hydrated individually."""
 
@@ -70,7 +81,7 @@ class _HydrateableResource(_Resource):
         self.__init__(**hydrated_fields)
 
 
-@dataclass
+@dataclass(eq=False)
 class Subject(_MatchableResource, _HydrateableResource):
     name: str
 
@@ -82,12 +93,12 @@ class Subject(_MatchableResource, _HydrateableResource):
     endpoint: str = "subject"
 
 
-@dataclass
+@dataclass(eq=False)
 class Language(_Resource):
     name: Optional[str] = None
 
 
-@dataclass
+@dataclass(eq=False)
 class _Asset(_HydrateableResource):
     """
     Abstract class representing fpr Translations, Transcriptions, and MediaFiles.
@@ -145,7 +156,7 @@ class _Asset(_HydrateableResource):
             )
 
 
-@dataclass
+@dataclass(eq=False)
 class Transcript(_Asset):
     url: str
     html: Optional[str] = None
@@ -157,7 +168,7 @@ class Transcript(_Asset):
         pass  # pylint: disable=unnecessary-pass
 
 
-@dataclass
+@dataclass(eq=False)
 class Translation(_Asset):
     url: str
     language: Union[Language, dict]
@@ -169,7 +180,7 @@ class Translation(_Asset):
         self.language = Language(**self.language)
 
 
-@dataclass
+@dataclass(eq=False)
 class MediaFile(_Asset):
     path: str
     raw: Optional[bytes] = None
@@ -180,19 +191,19 @@ class MediaFile(_Asset):
         self.url: str = self.path
 
 
-@dataclass
+@dataclass(eq=False)
 class Contributor(_MatchableResource, _HydrateableResource):
     name: str
     endpoint: str = "contributor"
 
 
-@dataclass
+@dataclass(eq=False)
 class Donor(_Resource):
     name: str
     endpoint: str = "donor"
 
 
-@dataclass
+@dataclass(eq=False)
 class Coverage(_MatchableResource, _HydrateableResource):
     uri: str
     name: str
@@ -200,7 +211,7 @@ class Coverage(_MatchableResource, _HydrateableResource):
     endpoint: str = "coverage"
 
 
-@dataclass
+@dataclass(eq=False)
 class Collection(_MatchableResource, _HydrateableResource):
     # Required Fields
     name: str
@@ -228,7 +239,7 @@ class Collection(_MatchableResource, _HydrateableResource):
     endpoint: str = "collection"
 
 
-@dataclass
+@dataclass(eq=False)
 class Repository(_MatchableResource, _HydrateableResource):
     name: str
     uri: Optional[str] = None
@@ -236,30 +247,30 @@ class Repository(_MatchableResource, _HydrateableResource):
     endpoint: str = "repository"
 
 
-@dataclass
+@dataclass(eq=False)
 class Publisher(_Resource):
     name: str
     value: str
     endpoint: str = "publisher"
 
 
-@dataclass
+@dataclass(eq=False)
 class Type(_Resource):
     name: str
 
 
-@dataclass
+@dataclass(eq=False)
 class Right(_Resource):
     name: str
     rights: str
 
 
-@dataclass
+@dataclass(eq=False)
 class Classification(_Resource):
     name: str
 
 
-@dataclass
+@dataclass(eq=False)
 class Document(_MatchableResource, _HydrateableResource):
 
     # pylint: disable=too-many-instance-attributes

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -8,13 +8,15 @@ import pytest
 import digitalarchive.models as models
 
 
-class TestResource:
+class TestMatchableResource:
     @unittest.mock.patch("digitalarchive.models.matching")
     def test_match(self, mock_matching):
         """Check appropriate model and kwargs passed to matching."""
         models.Subject.match(name="Soviet")
         mock_matching.ResourceMatcher.assert_called_with(models.Subject, name="Soviet")
 
+
+class TestHydrateableResource:
     @unittest.mock.patch("digitalarchive.models.api")
     def test_pull(self, mock_api):
         """Check appropriate endpoint and ID passed to get function."""
@@ -74,6 +76,85 @@ class TestDocument:
         mock_matching.ResourceMatcher.assert_called_with(
             models.Document, name="Soviet", model="Record"
         )
+
+    def test_valid_eq(self):
+        """Compare a search result doc and a hydrated doc."""
+        hydrated_doc = models.Document(
+            id=1,
+            uri="test",
+            title="test",
+            description="test",
+            doc_date="test",
+            frontend_doc_date="test",
+            slug="test",
+            source_created_at="test",
+            source_updated_at="test",
+            first_published_at="test",
+        )
+        unhydrated_doc = models.Document(
+            id=1,
+            uri="test",
+            title="test",
+            description="test",
+            doc_date="test",
+            frontend_doc_date="test",
+            slug="test",
+            source_created_at="test",
+            source_updated_at="test",
+            first_published_at="test",
+            pdf_generated_at="test_pdf_date",
+        )
+
+        assert hydrated_doc == unhydrated_doc
+
+    def test_invalid_eq(self):
+        doc1 = models.Document(
+            id="1",
+            uri="test",
+            title="test",
+            description="test",
+            doc_date="test",
+            frontend_doc_date="test",
+            slug="test",
+            source_created_at="test",
+            source_updated_at="test",
+            first_published_at="test",
+        )
+        doc2 = models.Document(
+            id="2",
+            uri="test",
+            title="test",
+            description="test",
+            doc_date="test",
+            frontend_doc_date="test",
+            slug="test",
+            source_created_at="test",
+            source_updated_at="test",
+            first_published_at="test",
+        )
+        assert doc1 != doc2
+
+    def test_invalid_eq_class(self):
+        collection = models.Subject(id="1", name="test_collection")
+        contributor = models.Contributor(id="1", name="test_contributor")
+        assert collection != contributor
+
+    def test_hash(self):
+        # Create dummy records.
+        contributor_1 = models.Contributor(id="1", name="test")
+        contributor_2 = models.Contributor(id="2", name="test")
+        contributor_3 = models.Contributor(id="3", name="test")
+        contributor_1_dupe = models.Contributor(id="1", name="test2")
+
+        # Create two overlapping sets.
+        contributor_set_1 = set([contributor_1, contributor_2])
+        contributor_set_2 = set([contributor_1_dupe, contributor_3])
+
+        # Merge sets
+        merged = contributor_set_1 | contributor_set_2
+
+        # Confirm merged sets has no dupes.
+        assert merged == {contributor_1, contributor_2, contributor_3}
 
 
 class TestAsset:


### PR DESCRIPTION
Some models will have different fields depending on whether they are hydrated or unhydrated. Setting __eq__ to only compare their ID will enable easier merging of result sets later. 