### PR TITLE
Feature/implement abc

### DIFF
--- a/digitalarchive/matching.py
+++ b/digitalarchive/matching.py
@@ -16,7 +16,7 @@ class ResourceMatcher:
     ResourceMatcher wraps search results and exposes methods for intereacting with a result set.
 
     Attributes:
-        list(:obj:`Generator` of :class:`digitalarchive.models._MatchableResource`) A Generator returning individual search results. Handles pagination of the DA API.
+        list(:obj:`Generator` of :class:`digitalarchive.models.Resource`) A Generator returning individual search results. Handles pagination of the DA API.
         count: The number of respondant records to the given search.
 
     """
@@ -24,7 +24,7 @@ class ResourceMatcher:
     # pylint: disable=protected-access
 
     def __init__(
-        self, resource_model: models._MatchableResource, items_per_page=200, **kwargs
+        self, resource_model: models.Resource, items_per_page=200, **kwargs
     ):
         """
         Wrapper for search and query related functions.
@@ -34,7 +34,7 @@ class ResourceMatcher:
         """
         self.model = resource_model
         self.query = kwargs
-        self.list: Generator[models._Resource, None, None]
+        self.list: Generator[models.Resource, None, None]
         self.count: int
 
         # if this is a request for a single record by ID, return only the record
@@ -83,7 +83,7 @@ class ResourceMatcher:
         # Wrap the response for SearchResult
         return {"list": [response]}
 
-    def _get_all_search_results(self, response) -> models._MatchableResource:
+    def _get_all_search_results(self, response) -> models.MatchingMixin:
         """Create Generator to handle search result pagination."""
         page = response["pagination"]["page"]
 
@@ -98,14 +98,14 @@ class ResourceMatcher:
             # Fetch new resources if needed.
             page += 1
 
-    def first(self) -> models._MatchableResource:
+    def first(self) -> models.MatchingMixin:
         """Return only the first record from a search result."""
         if isinstance(self.list, Generator):
             return next(self.list)
         elif isinstance(self.list, list):
             return self.list[0]
 
-    def all(self) -> List[models._MatchableResource]:
+    def all(self) -> List[models.MatchingMixin]:
         """Return all results from a search."""
         records = list(self.list)
         self.list = records

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -341,7 +341,7 @@ class TestCollection:
 
 class TestTranslation:
     def test_hydrate(self):
-        """Test hydration method for digitalarchive.models._Asset"""
+        """Test hydration method for digitalarchive.models.Asset"""
         # Fetch a translation
         test_doc = digitalarchive.Document.match(id=208400).first()
         test_translation = test_doc.translations[0]

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -52,7 +52,7 @@ class TestResourceMatcher:
         """Test Search API called with proper params."""
         # Run match
         mock_get_by_id.return_value = {"list": [{"id": 1}]}
-        test_match = matching.ResourceMatcher(models._Resource, id=1)
+        test_match = matching.ResourceMatcher(models.Resource, id=1)
 
         # Check search called with proper params.
         mock_get_by_id.assert_called_once()
@@ -60,7 +60,7 @@ class TestResourceMatcher:
         # Inspect list for proper data
         match_results = list(test_match.list)
         assert len(match_results) == 1
-        assert isinstance(match_results[0], models._Resource)
+        assert isinstance(match_results[0], models.Resource)
 
     @unittest.mock.patch("digitalarchive.api.get")
     def test_match_record_by_id(self, mock_api_get):
@@ -83,15 +83,15 @@ class TestResourceMatcher:
 
     def test_invalid_keyword(self):
         with pytest.raises(exceptions.InvalidSearchFieldError):
-            models._MatchableResource.match(test="test")
+            models.Collection.match(test="test")
 
     @unittest.mock.patch("digitalarchive.matching.ResourceMatcher._record_by_id")
     def test_first(self, mock_get_by_id):
         # Run match
         mock_get_by_id.return_value = {"list": [{"id": 1}]}
-        test_match = matching.ResourceMatcher(models._Resource, id=1).first()
+        test_match = matching.ResourceMatcher(models.Resource, id=1).first()
 
-        assert isinstance(test_match, models._Resource)
+        assert isinstance(test_match, models.Resource)
 
     @unittest.mock.patch("digitalarchive.api.search")
     def test_all(self, mock_search):
@@ -164,10 +164,10 @@ class TestResourceMatcher:
     def test_repr(self, mock_get_by_id):
         # Run match
         mock_get_by_id.return_value = {"list": [{"id": 1}]}
-        test_match = matching.ResourceMatcher(models._Resource, id=1)
+        test_match = matching.ResourceMatcher(models.Resource, id=1)
         assert (
             str(test_match)
-            == "ResourceMatcher(model=<class 'digitalarchive.models._Resource'>, query={'id': 1}, count=1)"
+            == "ResourceMatcher(model=<class 'digitalarchive.models.Resource'>, query={'id': 1}, count=1)"
         )
 
     @unittest.mock.patch("digitalarchive.api.search")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -441,7 +441,7 @@ class TestAsset:
         """ Test digitalarchive.models_Asset abstract parent can be instantiated."""
         # pylint: disable=protected-access
         # Create an Asset
-        test_asset = models._Asset(
+        test_asset = models.Asset(
             id="testid",
             filename="testfile",
             content_type="test_content_type",


### PR DESCRIPTION
Replaced use of `_` names with ABCs to prevent users from attemting to instantiate abstract bases from `digitalarchive.models`. 